### PR TITLE
Custom exception type from IOSseClient

### DIFF
--- a/lib/io.dart
+++ b/lib/io.dart
@@ -4,6 +4,17 @@ import 'package:http/http.dart';
 import 'package:sse_client/src/event_source_transformer.dart';
 import 'package:sse_client/src/sse_client.dart';
 
+class SseClientException implements Exception {
+  final String message;
+
+  SseClientException(this.message);
+
+  @override
+  String toString() {
+    return 'SseClientException: $message';
+  }
+}
+
 class IOSseClient extends SseClient {
   IOSseClient(Stream stream) : super(stream: stream);
 
@@ -12,19 +23,23 @@ class IOSseClient extends SseClient {
     final client = Client();
 
     incomingController = StreamController<String?>.broadcast(onListen: () {
-      var request = Request('GET', uri)
+      final request = Request('GET', uri)
         ..headers['Accept'] = 'text/event-stream';
 
-      client.send(request).then((response) {
-        if (response.statusCode == 200) {
-          response.stream.transform(EventSourceTransformer()).listen((event) {
-            incomingController.sink.add(event.data);
-          });
-        } else {
-          incomingController
-              .addError(Exception('Failed to connect to ${uri.toString()}'));
-        }
-      });
+      try {
+        client.send(request).then((response) {
+          if (response.statusCode == 200) {
+            response.stream.transform(EventSourceTransformer()).listen((event) {
+              incomingController.sink.add(event.data);
+            });
+          } else {
+            incomingController
+                .addError(Exception('Failed to connect to ${uri.toString()}'));
+          }
+        });
+      } catch (e) {
+        throw SseClientException('SseClientException, inner exception: $e');
+      }
     }, onCancel: () {
       incomingController.close();
     });

--- a/lib/io.dart
+++ b/lib/io.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:http/http.dart';
+import 'package:http/io_client.dart';
 import 'package:sse_client/src/event_source_transformer.dart';
 import 'package:sse_client/src/sse_client.dart';
 
@@ -20,30 +22,86 @@ class IOSseClient extends SseClient {
 
   factory IOSseClient.connect(Uri uri) {
     late StreamController<String?> incomingController;
-    final client = Client();
+    final client = ClientWithCustomExceptionType();
 
     incomingController = StreamController<String?>.broadcast(onListen: () {
       final request = Request('GET', uri)
         ..headers['Accept'] = 'text/event-stream';
 
-      try {
-        client.send(request).then((response) {
-          if (response.statusCode == 200) {
-            response.stream.transform(EventSourceTransformer()).listen((event) {
-              incomingController.sink.add(event.data);
-            });
-          } else {
-            incomingController
-                .addError(Exception('Failed to connect to ${uri.toString()}'));
-          }
-        });
-      } catch (e) {
-        throw SseClientException('SseClientException, inner exception: $e');
-      }
+      client.send(request).then((response) {
+        if (response.statusCode == 200) {
+          response.stream.transform(EventSourceTransformer()).listen((event) {
+            incomingController.sink.add(event.data);
+          });
+        } else {
+          incomingController.addError(
+              SseClientException('Failed to connect to ${uri.toString()}'));
+        }
+      });
     }, onCancel: () {
       incomingController.close();
     });
 
     return IOSseClient(incomingController.stream);
+  }
+}
+
+class ClientWithCustomExceptionType extends BaseClient {
+  /// The underlying `dart:io` HTTP client.
+  final HttpClient _inner;
+
+  ClientWithCustomExceptionType([HttpClient? inner])
+      : _inner = inner ?? HttpClient();
+
+  /// Sends an HTTP request and asynchronously returns the response.
+  @override
+  Future<IOStreamedResponse> send(BaseRequest request) async {
+    var stream = request.finalize();
+
+    try {
+      var ioRequest = (await _inner.openUrl(request.method, request.url))
+        ..followRedirects = request.followRedirects
+        ..maxRedirects = request.maxRedirects
+        ..contentLength = (request.contentLength ?? -1)
+        ..persistentConnection = request.persistentConnection;
+      request.headers.forEach((name, value) {
+        ioRequest.headers.set(name, value);
+      });
+
+      var response = await stream.pipe(ioRequest) as HttpClientResponse;
+
+      var headers = <String, String>{};
+      response.headers.forEach((key, values) {
+        headers[key] = values.join(',');
+      });
+
+      return IOStreamedResponse(
+          response.handleError((error) {
+            final httpException = error as HttpException;
+            throw SseClientException('handleError: ${httpException.message}');
+          }, test: (error) => error is HttpException),
+          response.statusCode,
+          contentLength:
+              response.contentLength == -1 ? null : response.contentLength,
+          request: request,
+          headers: headers,
+          isRedirect: response.isRedirect,
+          persistentConnection: response.persistentConnection,
+          reasonPhrase: response.reasonPhrase,
+          inner: response);
+    } on HttpException catch (error) {
+      throw SseClientException('HttpException: ${error.message}');
+    } catch (e) {
+      throw SseClientException('Exception: type: ${e.runtimeType}, e = $e');
+    }
+  }
+
+  /// Closes the client.
+  ///
+  /// Terminates all active connections. If a client remains unclosed, the Dart
+  /// process may not terminate.
+  @override
+  void close() {
+    _inner.close(force: true);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Provides client and server functionality for setting up bi-directional
   communication through Server Sent Events (SSE) and corresponding POST
   requests.
-version: 0.1.0
+version: 0.1.1
 homepage: https://www.github.com/jamiewest/sse_client
 
 environment:


### PR DESCRIPTION
When using SSE transport in https://github.com/jamiewest/signalr_core library, sometimes exceptions will "leak" up from IOSseClient to signalr_core and up to the application that is using signalr_core. These exceptions have no real signature, they are of type "ClientException" and with a generic stack trace and message from http.Client.

This PR changes so that sse_client still throws exceptions but with a custom type so that the calling application can catch this specific type and handle them accordingly. In this case, these are leaking up the application but by just ignoring these exception the signalr_core package will fire a reconnect if the connection is lost.

Steps to reproduce the bug:
1. Connect to a SignalR service using signalr_core library and make sure transport is set to SSE
2. Put the device into airplane mode or (at least for iOS) just turn off the screen with the physical button.
3. When the connection is lost, the http.Client inside sse_client library throws a ClientException that issues a reconnect in signalr_core but the exception is also leaking up to the calling application.

This fixes https://github.com/jamiewest/signalr_core/issues/58, at least for me.

NOTE! The code for the PR isn't the most sofisticated but it does the job.