### PR TITLE
Add close(), openEvents, errorEvents, readyState

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 doc/api/
 
 .vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -10,14 +10,10 @@ A simple usage example:
 import 'package:sse_client/sse_client.dart';
 
 void main() {
-  var sseClient = SseClient.connect(Uri.parse('http://localhost:5000/stream?channel=messages'));
-  var stream = sseClient.stream;
-  if (stream == null) {
-    print('Stream is not connected');
-    return;
-  }
-  stream.listen((event) {
-    print(event); // event is a String
+  final sseClient = SseClient.connect(Uri.parse('http://localhost:5000/stream?channel=messages'));
+
+  sseClient.stream.listen((String? event) {
+    print(event);
   });                                   
 }
 ```

--- a/example/sse_example.dart
+++ b/example/sse_example.dart
@@ -1,13 +1,9 @@
 import 'package:sse_client/sse_client.dart';
 
 void main() {
-  var sseClient = SseClient.connect(Uri.parse('http://localhost:5000/stream?channel=messages'));
-  var stream = sseClient.stream;
-  if (stream == null) {
-    print('Stream is not connected');
-    return;
-  }
-  stream.listen((event) {
-    print(event); // event is a String
+  final sseClient = SseClient.connect(Uri.parse('http://localhost:5000/stream?channel=messages'));
+
+  sseClient.stream.listen((String? event) {
+    print(event);
   });                                   
 }

--- a/lib/html.dart
+++ b/lib/html.dart
@@ -4,17 +4,49 @@ import 'dart:html';
 import 'package:sse_client/src/sse_client.dart';
 
 class HtmlSseClient extends SseClient {
-  HtmlSseClient(Stream stream) : super(stream: stream);
+  final Uri uri;
+  final bool withCredentials;
+  final EventSource eventSource;
 
-  factory HtmlSseClient.connect(Uri uri, {bool withCredentials = false}) {
-    final incomingController = StreamController<String?>();
-    final eventSource =
-        EventSource(uri.toString(), withCredentials: withCredentials);
+  final _messageController = StreamController<String?>.broadcast();
+  @override
+  Stream<String?> get stream => _messageController.stream;
 
+  final _errorController = StreamController<void>.broadcast();
+  @override
+  Stream<void> get errorEvents => _errorController.stream;
+
+  final _openController = StreamController<void>.broadcast();
+  @override
+  Stream<void> get openEvents => _openController.stream;
+
+  @override
+  int? get readyState => eventSource.readyState;
+
+  HtmlSseClient({
+    required this.uri,
+    this.withCredentials = false,
+  }) :
+      eventSource = EventSource(uri.toString(), withCredentials: withCredentials)
+  {
     eventSource.addEventListener('message', (Event message) {
-      incomingController.add((message as MessageEvent).data as String?);
+      _messageController.add((message as MessageEvent).data as String?);
     });
 
-    return HtmlSseClient(incomingController.stream);
+    eventSource.addEventListener('error', (Event message) {
+      _errorController.add(message);
+    });
+
+    eventSource.addEventListener('open', (Event message) {
+      _openController.add(message);
+    });
+  }
+
+  @override
+  void close() {
+    eventSource.close();
+    _messageController.close();
+    _errorController.close();
+    _openController.close();
   }
 }

--- a/lib/io.dart
+++ b/lib/io.dart
@@ -5,7 +5,10 @@ import 'package:sse_client/src/event_source_transformer.dart';
 import 'package:sse_client/src/sse_client.dart';
 
 class IOSseClient extends SseClient {
-  IOSseClient(Stream stream) : super(stream: stream);
+  @override
+  final Stream<String?> stream;
+
+  IOSseClient(this.stream);
 
   factory IOSseClient.connect(Uri uri) {
     late StreamController<String?> incomingController;
@@ -31,4 +34,22 @@ class IOSseClient extends SseClient {
 
     return IOSseClient(incomingController.stream);
   }
+
+  @override
+  void close() {
+    // TODO
+    throw UnimplementedError();
+  }
+
+  @override
+  // TODO: implement errors
+  Stream<void> get errorEvents => throw UnimplementedError();
+
+  @override
+  // TODO: implement
+  Stream<void> get openEvents => throw UnimplementedError();
+
+  @override
+  // TODO: implement
+  int? get readyState => throw UnimplementedError();
 }

--- a/lib/src/_connect_html.dart
+++ b/lib/src/_connect_html.dart
@@ -1,4 +1,4 @@
 import 'package:sse_client/html.dart';
 import 'package:sse_client/src/sse_client.dart';
 
-SseClient connect(Uri uri) => HtmlSseClient.connect(uri);
+SseClient connect(Uri uri) => HtmlSseClient(uri: uri);

--- a/lib/src/sse_client.dart
+++ b/lib/src/sse_client.dart
@@ -7,9 +7,11 @@ import '_connect_api.dart'
     // ignore: uri_does_not_exist
     if (dart.library.io) '_connect_io.dart' as platform;
 
+export 'sse_client_state.dart';
+
 /// A client for sse communication.
-class SseClient {
-  SseClient({this.stream});
+abstract class SseClient {
+  SseClient();
 
   /// Creates a new server sent events connection.
   ///
@@ -17,5 +19,10 @@ class SseClient {
   /// sends events in `text/event-stream` format.
   factory SseClient.connect(Uri uri) => platform.connect(uri);
 
-  final Stream? stream;
+  Stream<String?> get stream;
+  Stream<void> get errorEvents;
+  Stream<void> get openEvents;
+  int? get readyState;
+
+  void close();
 }

--- a/lib/src/sse_client_state.dart
+++ b/lib/src/sse_client_state.dart
@@ -1,0 +1,9 @@
+abstract class SseClientState {
+  SseClientState._();
+
+  // Duplicating the state constants from EventSource so that user
+  // does not have to import dart:html.
+  static const int connecting = 0;
+  static const int open = 1;
+  static const int closed = 2;
+}


### PR DESCRIPTION
For issue #8.

This request:
- Adds `close()` method to close the connection and stop listening.
- Adds `openEvents` and `errorEvents` streams to listen to connection status. They use `void` as type so we have room to decide on what to pass there, if anything. Relying on HTML's `Event` is not a good idea as we need a unified interface with IO.
- Adds `readyState` to get connection status.
- Adds `SseClientState` with state constants so that users do not have to import `dart:html` which is platform dependent.
- Uses broadcast for web `stream` for consistency with IO.
- Adds `<String?>` type to `stream`.
- Makes `stream` non-nullable as there were no ways for it to be null.
- Simplifies the usage example.

I only needed web for my project so I only implemented the new interfaces for web. They throw UnimplementedError in IO. I guess this PR is still beneficial because there are even more significant differences between web and IO, like in Issue #4.

I see no way it can break any existing user code.